### PR TITLE
Updated to latest macroquad/ggrs/matchbox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,16 +6,16 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-macroquad = "0.3"
+macroquad = "0.4.11"
 bytemuck = {version="1.7.3", features= ["derive"]}
 instant = {version="0.1.12"}
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 log = "0.4"
 async-executor = "1.4.1"
-ggrs = { version = "0.9.3"}
-matchbox_socket = {version = "0.5", features = ["ggrs-socket"] }
+ggrs = { version = "0.10.2"}
+matchbox_socket = {version = "0.10.0", features = ["ggrs"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-ggrs = { version = "0.9.3", features=["wasm-bindgen"]}
+ggrs = { version = "0.10.2", features=["wasm-bindgen"]}
 instant = {version="0.1.12", features= ["wasm-bindgen"]}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@
 
 Try it out yourself!
 
+### Basic Local Setup Instructions
+
+1. Install matchbox server:
+```sh
+cargo install matchbox_server
+```
+2. Launch matchbox server in a separate terminal window:
+```sh
+matchbox_server
+```
+3. Run the game in two different terminal windows:
+```sh
+cargo run
+```
+4. The game's code is configured to target default port local host matchbox_server. Thus once you type in the same lobby number (ex. 1234) in both game clients, they should connect via the matchbox server and you will have ggrs + macroquad working locally.
+
+### WASM/Web
+Follow instructions in `build-wasm.sh`.
+
 ## Licensing
 
 this project is dual-licensed under either

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -70,7 +70,7 @@ impl Lobby {
         let dest_x = screen_width() / 2.0;
         let dest_y = self.logo.height() * (dest_x / self.logo.width());
         draw_texture_ex(
-            self.logo,
+            &self.logo,
             screen_width() / 2. - dest_x / 2.,
             20.0,
             WHITE,


### PR DESCRIPTION
This was the only macroquad + ggrs example I could find, however it was out of date and using a recent rust version gave compilation errors. I think it's helpful to have this reasonably up to date once in a while so people have a reference for non-bevy ggrs usage with matchbox.

Went ahead and updated macroquad/ggrs/matchbox to latest versions, made code changes as needed, and added very basic instructions for non-web local testing.

